### PR TITLE
Add meta information to library so it is automatically AboutLibraries

### DIFF
--- a/circular-progress-view/src/main/res/values/aboutLibraries_strings.xml
+++ b/circular-progress-view/src/main/res/values/aboutLibraries_strings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="define_androidCircularProgressView">year;owner</string>
+    <string name="library_androidCircularProgressView_author">GuilhE</string>
+    <string name="library_androidCircularProgressView_authorWebsite">https://github.com/GuilhE/</string>
+    <string name="library_androidCircularProgressView_libraryName">CircularProgressView</string>
+    <string name="library_androidCircularProgressView_libraryDescription">A fancy CircularProgressView.</string>
+    <string name="library_androidCircularProgressView_libraryVersion">1.2.2</string>
+    <string name="library_androidCircularProgressView_libraryWebsite">https://github.com/GuilhE/android-circular-progress-view/</string>
+    <string name="library_androidCircularProgressView_licenseId">apache_2_0</string>
+    <string name="library_androidCircularProgressView_isOpenSource">true</string>
+    <string name="library_androidCircularProgressView_repositoryLink">https://github.com/GuilhE/android-circular-progress-view/</string>
+    <string name="library_androidCircularProgressView_classPath">com.github.guilhe.circularprogressview.CircularProgressView</string>
+    <!-- Custom variables section -->
+    <string name="library_androidCircularProgressView_owner">GuilhE</string>
+    <string name="library_androidCircularProgressView_year">2017</string>
+</resources>


### PR DESCRIPTION
AboutLibraries is a tool that allows to integrate a view which shows 3rd Party libraries info (licence, short explanation and author) for all 3rd party libreries in an android app. This file will allow AboutLibraries to automatically recognise "CircularProgressView" and show correct information.
Find more info on AboutLibraries: https://github.com/mikepenz/AboutLibraries/
Details how to format this file: https://github.com/mikepenz/AboutLibraries/wiki/HOWTODEV:-Include-in-your-library